### PR TITLE
Solver tab shortcut changed

### DIFF
--- a/ain_imager_src/imagerwindow.cpp
+++ b/ain_imager_src/imagerwindow.cpp
@@ -374,7 +374,7 @@ ImagerWindow::ImagerWindow(QWidget *parent) : QMainWindow(parent) {
 	create_telescope_tab(telescope_frame);
 
 	QFrame *solver_frame = new QFrame;
-	m_tools_tabbar->addTab(solver_frame, "&Solver");
+	m_tools_tabbar->addTab(solver_frame, "Sol&ver");
 	create_solver_tab(solver_frame);
 
 	/*


### PR DESCRIPTION
Hello,

The "&S" shortcut on the solver tab is already used by the "Settings" menu. I propose to set the shortcut  on "&v".

Best regards,

Blaise