### PR TITLE
Add keyboard shortcuts for moving telecope mount

### DIFF
--- a/ain_imager_src/telescope_tab.cpp
+++ b/ain_imager_src/telescope_tab.cpp
@@ -212,30 +212,35 @@ void ImagerWindow::create_telescope_tab(QFrame *telescope_frame) {
 	slew_frame_layout->addWidget(move_button, slew_row + 0, slew_col + 1);
 	connect(move_button, &QPushButton::pressed, this, &ImagerWindow::on_mount_move_north);
 	connect(move_button, &QPushButton::released, this, &ImagerWindow::on_mount_stop_north);
+	move_button->setShortcut(QKeySequence("W"));
 
 	move_button = new QPushButton("W");
 	move_button->setStyleSheet("min-width: 20px");
 	slew_frame_layout->addWidget(move_button, slew_row + 1, slew_col + 0);
 	connect(move_button, &QPushButton::pressed, this, &ImagerWindow::on_mount_move_west);
 	connect(move_button, &QPushButton::released, this, &ImagerWindow::on_mount_stop_west);
+	move_button->setShortcut(QKeySequence("A"));
 
 	move_button = new QPushButton("");
 	move_button->setStyleSheet("min-width: 20px");
 	move_button->setIcon(QIcon(":resource/stop.png"));
 	slew_frame_layout->addWidget(move_button, slew_row + 1, slew_col + 1);
 	connect(move_button, &QPushButton::clicked, this, &ImagerWindow::on_mount_abort);
+	move_button->setShortcut(QKeySequence("Space"));
 
 	move_button = new QPushButton("E");
 	move_button->setStyleSheet("min-width: 20px");
 	slew_frame_layout->addWidget(move_button, slew_row + 1, slew_col + 2);
 	connect(move_button, &QPushButton::pressed, this, &ImagerWindow::on_mount_move_east);
 	connect(move_button, &QPushButton::released, this, &ImagerWindow::on_mount_stop_east);
+	move_button->setShortcut(QKeySequence("D"));
 
 	move_button = new QPushButton("S");
 	move_button->setStyleSheet("min-width: 20px");
 	slew_frame_layout->addWidget(move_button, slew_row + 2, slew_col + 1);
 	connect(move_button, &QPushButton::pressed, this, &ImagerWindow::on_mount_move_south);
 	connect(move_button, &QPushButton::released, this, &ImagerWindow::on_mount_stop_south);
+	move_button->setShortcut(QKeySequence("S"));
 
 	slew_col = 0;
 	slew_row = 3;


### PR DESCRIPTION
This PR adds keyboard shortcuts for mount movement buttons in the "Telescope" tab of Ain Imager. The bindings are (button_name -> key):

- 'N' -> `W`
- 'W' -> `A`
- 'E' ->  `D`
- 'S' ->  `S`
- stop (abort motion) -> `Space`.

These keys (`W`, `A`, `D`, `S`, `Space`) were chosen to resemble key bindings usually used in gaming for movement and to leave arrow keys free to be potentially bound to something else in the future.  
It could be useful for people who don't have a joystick, for example (like me at the moment... :smile:), and prefer using the keyboard over the mouse.

Tested with "Mount Simulator" on Linux Ubuntu 22.04 "Jammy" with INDIGO Server v. 2.0-282. I haven't been able to compile and test on Windows yet.

I'm not very knowledgeable about C++ and Qt so maybe this should be reviewed for potential memory leaks or other bugs, although is a very small feature (it uses the `addShortcut` method on the `QPushButton` object).

Many thanks for all the great work with INDIGO.