### PR TITLE
prefix relative build path to enable builds from other dirs

### DIFF
--- a/ain_imager_src/ain_imager.pro
+++ b/ain_imager_src/ain_imager.pro
@@ -3,7 +3,7 @@ CONFIG += c++11 release app_bundle
 
 unix:mac {
 	CONFIG += app_bundle
-	ICON=../resource/appicon.icns
+	ICON=$$PWD/../resource/appicon.icns
 }
 
 QMAKE_CXXFLAGS += -O3 -g
@@ -24,85 +24,85 @@ DEFINES += QT_DEPRECATED_WARNINGS QZEROCONF_STATIC
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
-	main.cpp \
-	changeproperty.cpp \
-	qservicemodel.cpp \
-	capture_tab.cpp \
-	focuser_tab.cpp \
-	guider_tab.cpp \
-	telescope_tab.cpp \
-	customobject.cpp \
-	customobjectmodel.cpp \
-	qaddcustomobject.cpp \
-	solver_tab.cpp \
-	imagerwindow.cpp \
-	qindigoservice.cpp \
-	indigoclient.cpp \
-	qindigoservers.cpp \
-	propertycache.cpp \
-	handlepropertychange.cpp \
-	focusgraph.cpp \
-	blobpreview.cpp \
-	sequence_editor.cpp \
-	sequence_tab.cpp \
-	syncutils.cpp \
-	qconfigdialog.cpp \
-	../common_src/coordconv.c \
-	../object_data/indigo_cat_data.c \
-	../common_src/utils.cpp \
-	../common_src/imagepreview.cpp \
-	../common_src/imageviewer.cpp \
-	../common_src/fits.c \
-	../common_src/xisf.c \
-	../common_src/xml.c \
-	../common_src/stretcher.cpp \
-	../common_src/image_stats.cpp \
-	../common_src/dslr_raw.c \
-	../external/qcustomplot/qcustomplot.cpp
+	$$PWD/main.cpp \
+	$$PWD/changeproperty.cpp \
+	$$PWD/qservicemodel.cpp \
+	$$PWD/capture_tab.cpp \
+	$$PWD/focuser_tab.cpp \
+	$$PWD/guider_tab.cpp \
+	$$PWD/telescope_tab.cpp \
+	$$PWD/customobject.cpp \
+	$$PWD/customobjectmodel.cpp \
+	$$PWD/qaddcustomobject.cpp \
+	$$PWD/solver_tab.cpp \
+	$$PWD/imagerwindow.cpp \
+	$$PWD/qindigoservice.cpp \
+	$$PWD/indigoclient.cpp \
+	$$PWD/qindigoservers.cpp \
+	$$PWD/propertycache.cpp \
+	$$PWD/handlepropertychange.cpp \
+	$$PWD/focusgraph.cpp \
+	$$PWD/blobpreview.cpp \
+	$$PWD/sequence_editor.cpp \
+	$$PWD/sequence_tab.cpp \
+	$$PWD/syncutils.cpp \
+	$$PWD/qconfigdialog.cpp \
+	$$PWD/../common_src/coordconv.c \
+	$$PWD/../object_data/indigo_cat_data.c \
+	$$PWD/../common_src/utils.cpp \
+	$$PWD/../common_src/imagepreview.cpp \
+	$$PWD/../common_src/imageviewer.cpp \
+	$$PWD/../common_src/fits.c \
+	$$PWD/../common_src/xisf.c \
+	$$PWD/../common_src/xml.c \
+	$$PWD/../common_src/stretcher.cpp \
+	$$PWD/../common_src/image_stats.cpp \
+	$$PWD/../common_src/dslr_raw.c \
+	$$PWD/../external/qcustomplot/qcustomplot.cpp
 
 
 RESOURCES += \
-	../qdarkstyle/style.qrc \
-	../resource/control_panel.qss \
-	../resource/appicon.png \
-	../resource/indigo_logo.png \
-	../resource/save.png \
-	../resource/delete.png \
-	../resource/zoom-fit-best.png \
-	../resource/zoom-original.png \
-	../resource/bonjour_service.png \
-	../resource/manual_service.png \
-	../resource/no-preview.png \
-	../resource/led-red.png \
-	../resource/led-grey.png \
-	../resource/led-green.png \
-	../resource/led-orange.png \
-	../resource/led-red-cb.png \
-	../resource/led-green-cb.png \
-	../resource/led-orange-cb.png \
-	../resource/stop.png \
-	../resource/play.png \
-	../resource/pause.png \
-	../resource/record.png \
-	../resource/focus.png \
-	../resource/calibrate.png \
-	../resource/guide.png \
-	../resource/focus_in.png \
-	../resource/focus_out.png \
-	../resource/previous.png \
-	../resource/next.png \
-	../resource/zoom-in.png \
-	../resource/zoom-out.png \
-	../resource/arrow-up.png \
-	../resource/arrow-down.png \
-	../resource/edit.png \
-	../resource/folder.png \
-	../resource/download.png \
-	../resource/histogram.png \
-	../resource/error.wav \
-	../resource/ok.wav \
-	../resource/warning.wav \
-	../resource/spinner.gif
+	$$PWD/../qdarkstyle/style.qrc \
+	$$PWD/../resource/control_panel.qss \
+	$$PWD/../resource/appicon.png \
+	$$PWD/../resource/indigo_logo.png \
+	$$PWD/../resource/save.png \
+	$$PWD/../resource/delete.png \
+	$$PWD/../resource/zoom-fit-best.png \
+	$$PWD/../resource/zoom-original.png \
+	$$PWD/../resource/bonjour_service.png \
+	$$PWD/../resource/manual_service.png \
+	$$PWD/../resource/no-preview.png \
+	$$PWD/../resource/led-red.png \
+	$$PWD/../resource/led-grey.png \
+	$$PWD/../resource/led-green.png \
+	$$PWD/../resource/led-orange.png \
+	$$PWD/../resource/led-red-cb.png \
+	$$PWD/../resource/led-green-cb.png \
+	$$PWD/../resource/led-orange-cb.png \
+	$$PWD/../resource/stop.png \
+	$$PWD/../resource/play.png \
+	$$PWD/../resource/pause.png \
+	$$PWD/../resource/record.png \
+	$$PWD/../resource/focus.png \
+	$$PWD/../resource/calibrate.png \
+	$$PWD/../resource/guide.png \
+	$$PWD/../resource/focus_in.png \
+	$$PWD/../resource/focus_out.png \
+	$$PWD/../resource/previous.png \
+	$$PWD/../resource/next.png \
+	$$PWD/../resource/zoom-in.png \
+	$$PWD/../resource/zoom-out.png \
+	$$PWD/../resource/arrow-up.png \
+	$$PWD/../resource/arrow-down.png \
+	$$PWD/../resource/edit.png \
+	$$PWD/../resource/folder.png \
+	$$PWD/../resource/download.png \
+	$$PWD/../resource/histogram.png \
+	$$PWD/../resource/error.wav \
+	$$PWD/../resource/ok.wav \
+	$$PWD/../resource/warning.wav \
+	$$PWD/../resource/spinner.gif
 
 
 # Additional import path used to resolve QML modules in Qt Creator\'s code model
@@ -117,64 +117,70 @@ else: unix:!android: target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target
 
 HEADERS += \
-	qservicemodel.h \
-	imagerwindow.h \
-	qindigoservice.h \
-	indigoclient.h \
-	propertycache.h \
-	customobject.h \
-	customobjectmodel.h \
-	qaddcustomobject.h \
-	qindigoservers.h \
-	logger.h \
-	focusgraph.h \
-	conf.h \
-	widget_state.h \
-	blobpreview.h \
-	sequence_editor.h \
-	syncutils.h \
-	qconfigdialog.h \
-	../common_src/version.h \
-	../object_data/indigo_cat_data.h \
-	../common_src/utils.h \
-	../common_src/image_preview_lut.h \
-	../common_src/imagepreview.h \
-	../common_src/imageviewer.h \
-	../common_src/fits.h \
-	../common_src/xisf.h \
-	../common_src/xml.h \
-	../common_src/pixelformat.h \
-	../external/qcustomplot/qcustomplot.h \
-	../common_src/coordconv.h \
-	../common_src/stretcher.h \
-	../common_src/image_stats.h \
-	../common_src/dslr_raw.h
+	$$PWD/qservicemodel.h \
+	$$PWD/imagerwindow.h \
+	$$PWD/qindigoservice.h \
+	$$PWD/indigoclient.h \
+	$$PWD/propertycache.h \
+	$$PWD/customobject.h \
+	$$PWD/customobjectmodel.h \
+	$$PWD/qaddcustomobject.h \
+	$$PWD/qindigoservers.h \
+	$$PWD/logger.h \
+	$$PWD/focusgraph.h \
+	$$PWD/conf.h \
+	$$PWD/widget_state.h \
+	$$PWD/blobpreview.h \
+	$$PWD/sequence_editor.h \
+	$$PWD/syncutils.h \
+	$$PWD/qconfigdialog.h \
+	$$PWD/../common_src/version.h \
+	$$PWD/../object_data/indigo_cat_data.h \
+	$$PWD/../common_src/utils.h \
+	$$PWD/../common_src/image_preview_lut.h \
+	$$PWD/../common_src/imagepreview.h \
+	$$PWD/../common_src/imageviewer.h \
+	$$PWD/../common_src/fits.h \
+	$$PWD/../common_src/xisf.h \
+	$$PWD/../common_src/xml.h \
+	$$PWD/../common_src/pixelformat.h \
+	$$PWD/../external/qcustomplot/qcustomplot.h \
+	$$PWD/../common_src/coordconv.h \
+	$$PWD/../common_src/stretcher.h \
+	$$PWD/../common_src/image_stats.h \
+	$$PWD/../common_src/dslr_raw.h
 
-INCLUDEPATH += "../indigo/indigo_libs" + "../external" + "../external/libraw/" + "../external/lz4/" + "../common_src" + "../object_data" + "../ain_imager_src"
+INCLUDEPATH += "$$PWD/../indigo/indigo_libs" \
+			   "$$PWD/../external" \
+			   "$$PWD/../external/libraw/" \
+			   "$$PWD/../external/lz4/" \
+			   "$$PWD/../common_src" \
+			   "$$PWD/../object_data" \
+			   "$$PWD/../ain_imager_src"
 
 unix:!mac | win32 {
-	LIBS += -L"../external/libraw/lib" -L"../../external/libraw/lib" -L"../external/lz4" -L"../../external/lz4" -lraw -lz
+	LIBS += -L"$$PWD/../external/libraw/lib" -L"$$PWD/../../external/libraw/lib" -L"$$PWD/../external/lz4" -L"$$PWD/../../external/lz4" -lraw -lz
 }
 
 unix {
-	INCLUDEPATH += "../external/libjpeg"
+	INCLUDEPATH += "$$PWD/../external/libjpeg"
 }
 
 unix:mac {
-	LIBS += -L"../external/libraw/lib" -L"../external/lz4" -lraw -lz \
-		-L"../external/libjpeg/.libs" -L"../indigo/build/lib" -lindigo -ljpeg -llz4
+	LIBS += -L"$$PWD/../external/libraw/lib" -L"$$PWD/../external/lz4" -lraw -lz \
+			-L"$$PWD/../external/libjpeg/.libs" -L"$$PWD/../indigo/build/lib" -lindigo -ljpeg -llz4
 }
 
 unix:!mac {
-	LIBS += -L"../external/libjpeg/.libs" -L"../indigo/build/lib" -lindigo -ljpeg -l:liblz4.a
+	LIBS += -L"$$PWD/../external/libjpeg/.libs" -L"$$PWD/../indigo/build/lib" -lindigo -ljpeg -l:liblz4.a
 }
 
 DISTFILES += \
-	README.md \
-	LICENCE.md \
+	$$PWD/README.md \
+	$$PWD/LICENCE.md
 
 win32 {
 	DEFINES += INDIGO_WINDOWS
-	INCLUDEPATH += ../../external/indigo_sdk/include
-	LIBS += -llz4 ../../external/indigo_sdk/lib/libindigo_client.lib -lws2_32
+	INCLUDEPATH += $$PWD/../../external/indigo_sdk/include
+	LIBS += -llz4 $$PWD/../../external/indigo_sdk/lib/libindigo_client.lib -lws2_32
 }

--- a/ain_viewer_src/ain_viewer.pro
+++ b/ain_viewer_src/ain_viewer.pro
@@ -3,7 +3,7 @@ CONFIG += c++11 debug
 
 unix:mac {
 	CONFIG += app_bundle
-	ICON=../resource/ain_viewer.icns
+	ICON=$$PWD/../resource/ain_viewer.icns
 }
 
 QMAKE_CXXFLAGS += -O3
@@ -24,36 +24,36 @@ DEFINES += QT_DEPRECATED_WARNINGS QZEROCONF_STATIC
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
-	main.cpp \
-	textdialog.cpp \
-	viewerwindow.cpp \
-	../common_src/coordconv.c \
-	../common_src/utils.cpp \
-	../common_src/imagepreview.cpp \
-	../common_src/imageviewer.cpp \
-	../common_src/image_stats.cpp \
-	../common_src/fits.c \
-	../common_src/raw_to_fits.c \
-	../common_src/xisf.c \
-	../common_src/xml.c \
-	../common_src/dslr_raw.c \
-	../common_src/stretcher.cpp
+	$$PWD/main.cpp \
+	$$PWD/textdialog.cpp \
+	$$PWD/viewerwindow.cpp \
+	$$PWD/../common_src/coordconv.c \
+	$$PWD/../common_src/utils.cpp \
+	$$PWD/../common_src/imagepreview.cpp \
+	$$PWD/../common_src/imageviewer.cpp \
+	$$PWD/../common_src/image_stats.cpp \
+	$$PWD/../common_src/fits.c \
+	$$PWD/../common_src/raw_to_fits.c \
+	$$PWD/../common_src/xisf.c \
+	$$PWD/../common_src/xml.c \
+	$$PWD/../common_src/dslr_raw.c \
+	$$PWD/../common_src/stretcher.cpp
 
 RESOURCES += \
-	../qdarkstyle/style.qrc \
-	../resource/control_panel.qss \
-	../resource/ain_viewer.png \
-	../resource/previous.png \
-	../resource/next.png \
-	../resource/indigo_logo.png \
-	../resource/zoom-fit-best.png \
-	../resource/zoom-original.png \
-	../resource/bonjour_service.png \
-	../resource/manual_service.png \
-	../resource/no-preview.png \
-	../resource/zoom-in.png \
-	../resource/zoom-out.png \
-	../resource/histogram.png
+	$$PWD/../qdarkstyle/style.qrc \
+	$$PWD/../resource/control_panel.qss \
+	$$PWD/../resource/ain_viewer.png \
+	$$PWD/../resource/previous.png \
+	$$PWD/../resource/next.png \
+	$$PWD/../resource/indigo_logo.png \
+	$$PWD/../resource/zoom-fit-best.png \
+	$$PWD/../resource/zoom-original.png \
+	$$PWD/../resource/bonjour_service.png \
+	$$PWD/../resource/manual_service.png \
+	$$PWD/../resource/no-preview.png \
+	$$PWD/../resource/zoom-in.png \
+	$$PWD/../resource/zoom-out.png \
+	$$PWD/../resource/histogram.png
 
 
 # Additional import path used to resolve QML modules in Qt Creator\'s code model
@@ -68,49 +68,56 @@ else: unix:!android: target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target
 
 HEADERS += \
-	viewerwindow.h \
-	textdialog.h \
-	conf.h \
-	../common_src/version.h \
-	../common_src/utils.h \
-	../common_src/image_preview_lut.h \
-	../common_src/imagepreview.h \
-	../common_src/imageviewer.h \
-	../common_src/image_stats.h \
-	../common_src/fits.h \
-	../common_src/raw_to_fits.h \
-	../common_src/xisf.h \
-	../common_src/xml.h \
-	../common_src/pixelformat.h \
-	../common_src/coordconv.h \
-	../common_src/dslr_raw.h \
-	../common_src/stretcher.h
+	$$PWD/viewerwindow.h \
+	$$PWD/textdialog.h \
+	$$PWD/conf.h \
+	$$PWD/../common_src/version.h \
+	$$PWD/../common_src/utils.h \
+	$$PWD/../common_src/image_preview_lut.h \
+	$$PWD/../common_src/imagepreview.h \
+	$$PWD/../common_src/imageviewer.h \
+	$$PWD/../common_src/image_stats.h \
+	$$PWD/../common_src/fits.h \
+	$$PWD/../common_src/raw_to_fits.h \
+	$$PWD/../common_src/xisf.h \
+	$$PWD/../common_src/xml.h \
+	$$PWD/../common_src/pixelformat.h \
+	$$PWD/../common_src/coordconv.h \
+	$$PWD/../common_src/dslr_raw.h \
+	$$PWD/../common_src/stretcher.h
 
 #unix:!mac {
 #    CONFIG += link_pkgconfig
 #    PKGCONFIG += indigo
 #}
 
-INCLUDEPATH += "../indigo/indigo_libs" + "../external" + "../external/qtzeroconf/" + "../external/libraw/" + "../external/lz4/" + "../common_src" + "../ain_viewer_src"
-LIBS += -L"../external/libraw/lib" -L"../../external/libraw/lib" -L"../../external/lz4" -L"../external/lz4" -lraw -lz
+INCLUDEPATH += "$$PWD/../indigo/indigo_libs "\
+			   "$$PWD/../external" \
+			   "$$PWD/../external/qtzeroconf/" \
+			   "$$PWD/../external/libraw/" \
+			   "$$PWD/../external/lz4/" \
+			   "$$PWD/../common_src" \
+			   "$$PWD/../ain_viewer_src"
+
+LIBS += -L"$$PWD/../external/libraw/lib" -L"$$PWD/../../external/libraw/lib" -"L$$PWD/../../external/lz4" -L"$$PWD/../external/lz4" -lraw -lz
 
 unix:!mac {
-	INCLUDEPATH += "../external/libjpeg"
-	LIBS += -L"../external/libjpeg/.libs" -L"../indigo/build/lib" -l:libindigo.a -lz -ljpeg -l:liblz4.a
+	INCLUDEPATH += "$$PWD/../external/libjpeg"
+	LIBS += -L"$$PWD/../external/libjpeg/.libs" -"L$$PWD/../indigo/build/lib" -l:libindigo.a -lz -ljpeg -l:liblz4.a
 	#LIBS += -L"../external/libjpeg/.libs" -L"../indigo/build/lib" -lindigo -ljpeg -l:liblz4.a
 }
 
 unix:mac {
-	INCLUDEPATH += "../external/libjpeg"
-	LIBS += -L"../external/libjpeg/.libs" -L"../indigo/build/lib" -lindigo -ljpeg -llz4
+	INCLUDEPATH += "$$PWD/../external/libjpeg"
+	LIBS += -L"$$PWD/../external/libjpeg/.libs" -L"$$PWD/../indigo/build/lib" -lindigo -ljpeg -llz4
 }
 
 DISTFILES += \
-	README.md \
-	LICENCE.md \
+	$$PWD/README.md \
+	$$PWD/LICENCE.md
 
 win32 {
 	DEFINES += INDIGO_WINDOWS
-	INCLUDEPATH += ../../external/indigo_sdk/include
-	LIBS += -llz4 ../../external/indigo_sdk/lib/libindigo_client.lib -lws2_32
+	INCLUDEPATH += $$PWD/../../external/indigo_sdk/include
+	LIBS += -llz4 $$PWD/../../external/indigo_sdk/lib/libindigo_client.lib -lws2_32
 }


### PR DESCRIPTION
I prefixed all relative build paths with the current project directory to enable building in QtCreator, or more generally in other directories.

Using QtCreator enables the use of automated checks for migrating to Qt6.

These are my goals in the future which are enabled by this PR:
- fix clang-tidy / clazy warnings
- migrate to Qt6
- move from more or less deprecated qmake to cmake
- include external libs via cmake
- update external libs