### PR TITLE
List resources in qrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ external/libjpeg/missing
 external/libjpeg/rdjpgcom
 external/libjpeg/wrjpgcom
 
+external/indigo_sdk/lib
+external/libraw/lib
+external/lz4/dll
+external/lz4/liblz4.a
+external/lz4/liblz4-dll.rc
+
+
 ain_imager_src/Makefile*
 ain_imager_src/ain_imager
 ain_imager_src/moc/*
@@ -55,7 +62,8 @@ windows/ain_imager_32
 windows/ain_imager_64
 windows/ain_viewer_32
 windows/ain_viewer_64
-windows/Outout
+windows/Output
+
 
 
 

--- a/ain_imager_src/ain_imager.pro
+++ b/ain_imager_src/ain_imager.pro
@@ -63,46 +63,7 @@ SOURCES += \
 
 RESOURCES += \
 	$$PWD/../qdarkstyle/style.qrc \
-	$$PWD/../resource/control_panel.qss \
-	$$PWD/../resource/appicon.png \
-	$$PWD/../resource/indigo_logo.png \
-	$$PWD/../resource/save.png \
-	$$PWD/../resource/delete.png \
-	$$PWD/../resource/zoom-fit-best.png \
-	$$PWD/../resource/zoom-original.png \
-	$$PWD/../resource/bonjour_service.png \
-	$$PWD/../resource/manual_service.png \
-	$$PWD/../resource/no-preview.png \
-	$$PWD/../resource/led-red.png \
-	$$PWD/../resource/led-grey.png \
-	$$PWD/../resource/led-green.png \
-	$$PWD/../resource/led-orange.png \
-	$$PWD/../resource/led-red-cb.png \
-	$$PWD/../resource/led-green-cb.png \
-	$$PWD/../resource/led-orange-cb.png \
-	$$PWD/../resource/stop.png \
-	$$PWD/../resource/play.png \
-	$$PWD/../resource/pause.png \
-	$$PWD/../resource/record.png \
-	$$PWD/../resource/focus.png \
-	$$PWD/../resource/calibrate.png \
-	$$PWD/../resource/guide.png \
-	$$PWD/../resource/focus_in.png \
-	$$PWD/../resource/focus_out.png \
-	$$PWD/../resource/previous.png \
-	$$PWD/../resource/next.png \
-	$$PWD/../resource/zoom-in.png \
-	$$PWD/../resource/zoom-out.png \
-	$$PWD/../resource/arrow-up.png \
-	$$PWD/../resource/arrow-down.png \
-	$$PWD/../resource/edit.png \
-	$$PWD/../resource/folder.png \
-	$$PWD/../resource/download.png \
-	$$PWD/../resource/histogram.png \
-	$$PWD/../resource/error.wav \
-	$$PWD/../resource/ok.wav \
-	$$PWD/../resource/warning.wav \
-	$$PWD/../resource/spinner.gif
+	$$PWD/../resource/ain_viewer.qrc
 
 
 # Additional import path used to resolve QML modules in Qt Creator\'s code model

--- a/ain_viewer_src/ain_viewer.pro
+++ b/ain_viewer_src/ain_viewer.pro
@@ -41,19 +41,7 @@ SOURCES += \
 
 RESOURCES += \
 	$$PWD/../qdarkstyle/style.qrc \
-	$$PWD/../resource/control_panel.qss \
-	$$PWD/../resource/ain_viewer.png \
-	$$PWD/../resource/previous.png \
-	$$PWD/../resource/next.png \
-	$$PWD/../resource/indigo_logo.png \
-	$$PWD/../resource/zoom-fit-best.png \
-	$$PWD/../resource/zoom-original.png \
-	$$PWD/../resource/bonjour_service.png \
-	$$PWD/../resource/manual_service.png \
-	$$PWD/../resource/no-preview.png \
-	$$PWD/../resource/zoom-in.png \
-	$$PWD/../resource/zoom-out.png \
-	$$PWD/../resource/histogram.png
+	$$PWD/../resource/ain_viewer.qrc
 
 
 # Additional import path used to resolve QML modules in Qt Creator\'s code model

--- a/resource/ain_imager.qrc
+++ b/resource/ain_imager.qrc
@@ -1,0 +1,44 @@
+<RCC>
+	<qresource prefix="/resource">
+		<file>control_panel.qss</file>
+		<file>appicon.png</file>
+		<file>indigo_logo.png</file>
+		<file>save.png</file>
+		<file>delete.png</file>
+		<file>zoom-fit-best.png</file>
+		<file>zoom-original.png</file>
+		<file>bonjour_service.png</file>
+		<file>manual_service.png</file>
+		<file>no-preview.png</file>
+		<file>led-red.png</file>
+		<file>led-grey.png</file>
+		<file>led-green.png</file>
+		<file>led-orange.png</file>
+		<file>led-red-cb.png</file>
+		<file>led-green-cb.png</file>
+		<file>led-orange-cb.png</file>
+		<file>stop.png</file>
+		<file>play.png</file>
+		<file>pause.png</file>
+		<file>record.png</file>
+		<file>focus.png</file>
+		<file>calibrate.png</file>
+		<file>guide.png</file>
+		<file>focus_in.png</file>
+		<file>focus_out.png</file>
+		<file>previous.png</file>
+		<file>next.png</file>
+		<file>zoom-in.png</file>
+		<file>zoom-out.png</file>
+		<file>arrow-up.png</file>
+		<file>arrow-down.png</file>
+		<file>edit.png</file>
+		<file>folder.png</file>
+		<file>download.png</file>
+		<file>histogram.png</file>
+		<file>error.wav</file>
+		<file>ok.wav</file>
+		<file>warning.wav</file>
+		<file>spinner.gif</file>
+	</qresource>
+</RCC>

--- a/resource/ain_viewer.qrc
+++ b/resource/ain_viewer.qrc
@@ -1,0 +1,17 @@
+<RCC>
+	<qresource prefix="/resource">
+		<file>control_panel.qss</file>
+		<file>ain_viewer.png</file>
+		<file>previous.png</file>
+		<file>next.png</file>
+		<file>indigo_logo.png</file>
+		<file>zoom-fit-best.png</file>
+		<file>zoom-original.png</file>
+		<file>bonjour_service.png</file>
+		<file>manual_service.png</file>
+		<file>no-preview.png</file>
+		<file>zoom-in.png</file>
+		<file>zoom-out.png</file>
+		<file>histogram.png</file>
+	</qresource>
+</RCC>


### PR DESCRIPTION
Listing resources in seperate .qrc files is required for qt6 but it also works in qt 5.15.

So that will reduce the amount of changes when we switch to qt6.