### PR TITLE
add qt version info to about dialog

### DIFF
--- a/ain_imager_src/imagerwindow.cpp
+++ b/ain_imager_src/imagerwindow.cpp
@@ -1495,6 +1495,7 @@ void ImagerWindow::on_about_act() {
 		AIN_VERSION
 		" (" + QString::number(platform_bits) + "bit) <br>"
 		"<br>INDIGO framework version " + QString(indigo_version) + "<br>"
+		"<br>Qt version: " + QT_VERSION_STR + "<br>"
 		"<br>"
 		"Author:<br>"
 		"Rumen G.Bogdanovski<br>"

--- a/ain_viewer_src/viewerwindow.cpp
+++ b/ain_viewer_src/viewerwindow.cpp
@@ -754,6 +754,7 @@ void ViewerWindow::on_about_act() {
 		"Version "
 		AIN_VERSION
 		" (" + QString::number(platform_bits) + "bit) <br>"
+		"<br>Qt version: " + QT_VERSION_STR + "<br>"
 		"<br>"
 		"Author:<br>"
 		"Rumen G.Bogdanovski<br>"


### PR DESCRIPTION
This is so that I don't get confused when testing and also could help debugging user issues.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/18c84250-33af-4de1-ac7e-cbffe84931bf">
