### PR TITLE
move from QAtomicInt::store to QAtomicInt::storeRelaxed

### DIFF
--- a/ain_imager_src/indigoclient.cpp
+++ b/ain_imager_src/indigoclient.cpp
@@ -133,7 +133,7 @@ static bool download_blob_async(indigo_property *property, QAtomicInt *downloadi
 				free(blob_item);
 			}
 		}
-		downloading->store(0);
+		downloading->storeRelaxed(0);
 		if( downloading == &client.imager_downloading) {
 			emit(client.imager_download_completed());
 		}


### PR DESCRIPTION
move from deprecated QAtomicInt::store to modern QAtomicInt::storeRelaxed which works on 5.15 and 6.