### PR TITLE
move from QMatrix to QTransform

### DIFF
--- a/common_src/imageviewer.cpp
+++ b/common_src/imageviewer.cpp
@@ -714,7 +714,6 @@ void ImageViewer::setMatrix() {
 
 	m_view->setTransform(matrix);
 	emit zoomChanged(m_view->transform().m11());
-	emit zoomChanged(m_view->matrix().m11());
 }
 
 void ImageViewer::zoomFit() {

--- a/common_src/imageviewer.cpp
+++ b/common_src/imageviewer.cpp
@@ -709,20 +709,21 @@ void ImageViewer::addTool(QWidget *tool) {
 void ImageViewer::setMatrix() {
 	qreal scale = m_zoom_level / 100.0;
 
-	QMatrix matrix;
+	QTransform matrix;
 	matrix.scale(scale, scale);
 
-	m_view->setMatrix(matrix);
+	m_view->setTransform(matrix);
+	emit zoomChanged(m_view->transform().m11());
 	emit zoomChanged(m_view->matrix().m11());
 }
 
 void ImageViewer::zoomFit() {
 	m_view->fitInView(m_pixmap, Qt::KeepAspectRatio);
-	m_zoom_level = (100.0 * m_view->matrix().m11());
+	m_zoom_level = (100.0 * m_view->transform().m11());
 	showZoom();
 	indigo_debug("Zoom FIT = %.2f", m_zoom_level);
 	m_fit = true;
-	emit zoomChanged(m_view->matrix().m11());
+	emit zoomChanged(m_view->transform().m11());
 }
 
 void ImageViewer::zoomOriginal() {


### PR DESCRIPTION
Replace deprecated type with more modern one, which is in Qt5.15 and Qt6.