### PR TITLE
Fix two crashes

### DIFF
--- a/ain_imager_src/imagerwindow.cpp
+++ b/ain_imager_src/imagerwindow.cpp
@@ -955,22 +955,18 @@ bool ImagerWindow::show_preview_in_guider_viewer(QString &key) {
 
 void ImagerWindow::play_sound(int alarm) {
 	if (conf.sound_notification_level) {
-		static QSoundEffect sound_effect; // static otherwise it will not play sounds with Qt6
 		switch (alarm) {
 		case AIN_NO_SOUND:
 			return;
 		case AIN_ALERT_SOUND:
-			sound_effect.setSource(QUrl("qrc:/resource/error.wav"));
-			sound_effect.play();
+			if (m_sound_alert) m_sound_alert->play();
 			return;
 		case AIN_WARNING_SOUND:
-			sound_effect.setSource(QUrl("qrc:/resource/warning.wav"));
-			sound_effect.play();
+			if (m_sound_warning) m_sound_warning->play();
 			return;
 		case AIN_OK_SOUND:
 			if (conf.sound_notification_level > AIN_WARNING_SOUND) {
-				sound_effect.setSource(QUrl("qrc:/resource/ok.wav"));
-				sound_effect.play();
+				if (m_sound_ok) m_sound_ok->play();
 			}
 			return;
 		}

--- a/common_src/utils.cpp
+++ b/common_src/utils.cpp
@@ -63,7 +63,10 @@ void get_timestamp(char *timestamp_str) {
 #else
 	strftime(timestamp_str, 255, "%Y-%m-%d %H:%M:%S", localtime((const time_t *) &tmnow.tv_sec));
 #endif
-	snprintf(timestamp_str + strlen(timestamp_str), 255, ".%03ld", tmnow.tv_usec/1000);
+	size_t length = strlen(timestamp_str);
+	if (length < 255) {
+		snprintf(timestamp_str + length, 255 - length, ".%03ld", tmnow.tv_usec/1000);
+	}
 }
 
 void get_date(char *date_str) {
@@ -153,7 +156,10 @@ void get_time(char *time_str) {
 #else
 	strftime(time_str, 255, "%H:%M:%S", localtime((const time_t *) &tmnow.tv_sec));
 #endif
-	snprintf(time_str + strlen(time_str), 255, ".%03ld", tmnow.tv_usec/1000);
+	size_t length = strlen(time_str);
+	if (length < 255) {
+		snprintf(time_str + length, 255 - length, ".%03ld", tmnow.tv_usec/1000);
+	}
 }
 
 void get_current_output_dir(char *output_dir, char *prefix) {


### PR DESCRIPTION
Both are happening for me on Fedora 44 aarch64 with custom RPM package (https://github.com/im-0/fedora-rpm.indigo-imager)

## Crash on startup when built with _FORTIFY_SOURCE=2

Backtrace:

		#0  __pthread_kill_implementation (threadid=281474716287008, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
		#1  0x0000fffff5ab002c [PAC] in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
		#2  0x0000fffff5a5b89c in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
		#3  0x0000fffff5a46720 [PAC] in __GI_abort () at abort.c:77
		#4  0x0000fffff5aa28b8 [PAC] in __libc_message_impl (vma_name=vma_name@entry=0xfffff5b85cd0 "glibc: fatal", fmt=fmt@entry=0xfffff5b8be28 "*** %s ***: terminated\n")
				at ../sysdeps/posix/libc_fatal.c:138
		#5  0x0000fffff5b24be4 [PAC] in __libc_message_wrapper (vmaname=0xfffff5b85cd0 "glibc: fatal", fmt=0xfffff5b8be28 "*** %s ***: terminated\n") at ../include/stdio.h:203
		#6  __GI___fortify_fail (msg=msg@entry=0xfffff5b8bdd8 "buffer overflow detected") at fortify_fail.c:24
		#7  0x0000fffff5b24358 [PAC] in __GI___chk_fail () at chk_fail.c:28
		#8  0x0000fffff5b25ca0 [PAC] in ___snprintf_chk (s=<optimized out>, maxlen=<optimized out>, flag=<optimized out>, slen=<optimized out>, format=<optimized out>) at snprintf_chk.c:29
		#9  0x0000aaaaaab276c0 [PAC] in snprintf (__s=<optimized out>, __n=255, __fmt=0xaaaaaac3b370 ".%03ld") at /usr/include/bits/stdio2.h:68
		#10 get_time (time_str=0xffffffffc068 "07:16:38") at ../common_src/utils.cpp:156
		#11 ImagerWindow::window_log (this=0xffffffffcd18, message=0xffffffffc3c8 "Server @ rsdesktop: Driver 'indigo_agent_astrometry' failed to load: unresolved dependencies", state=3)
				at /usr/src/debug/indigo-imager-2.13.0-1.fc44.aarch64/ain_imager_src/imagerwindow.cpp:773
		#12 0x0000aaaaaab551a0 [PAC] in ImagerWindow::on_window_log (this=0xffffffffcd18, property=<optimized out>, message=<optimized out>)
				at /usr/src/debug/indigo-imager-2.13.0-1.fc44.aarch64/ain_imager_src/handlepropertychange.cpp:3005
		#13 0x0000aaaaaab271bc [PAC] in ImagerWindow::on_message_received
				(this=0xffffffffcd18, device_name=0xffff68357160 "Server @ rsdesktop", property_name=0x0, property_state=3, message=0xffff6835a3a0 "Driver 'indigo_agent_astrometry' failed to load: unresolved dependencies") at /usr/src/debug/indigo-imager-2.13.0-1.fc44.aarch64/ain_imager_src/imagerwindow.cpp:1288
		#14 0x0000fffff61b16d4 [PAC] in QObject::event (this=<optimized out>, e=<optimized out>) at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qobject.cpp:1479
		#15 0x0000fffff75e60a8 [PAC] in QApplicationPrivate::notify_helper (this=<optimized out>, receiver=0xffffffffcd18, e=0xffff6835a5b0)
				at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/widgets/kernel/qapplication.cpp:3276
		#16 0x0000fffff613dc64 [PAC] in QCoreApplication::notifyInternal2 (receiver=receiver@entry=0xffffffffcd18, event=event@entry=0xffff6835a5b0)
				at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qcoreapplication.cpp:1114
		#17 0x0000fffff613dce8 [PAC] in QCoreApplication::sendEvent (receiver=receiver@entry=0xffffffffcd18, event=event@entry=0xffff6835a5b0)
				at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qcoreapplication.cpp:1559
		#18 0x0000fffff614210c in QCoreApplicationPrivate::sendPostedEvents (receiver=0x0, event_type=0, data=0xaaaaab512360)
				at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qcoreapplication.cpp:1914
		#19 0x0000fffff6478dd4 [PAC] in postEventSourceDispatch (s=0xaaaaab516da0) at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qeventdispatcher_glib.cpp:248
		#20 0x0000fffff53acfbc [PAC] in g_main_dispatch (context=0xffffd8000f00) at ../glib/gmain.c:3591
		#21 g_main_context_dispatch_unlocked (context=0xffffd8000f00) at ../glib/gmain.c:4451
		#22 0x0000fffff53b13f8 [PAC] in g_main_context_iterate_unlocked (context=context@entry=0xffffd8000f00, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>)
				at ../glib/gmain.c:4516
		#23 0x0000fffff53b1588 [PAC] in g_main_context_iteration (context=0xffffd8000f00, may_block=1) at ../glib/gmain.c:4582
		#24 0x0000fffff6478338 [PAC] in QEventDispatcherGlib::processEvents (this=0xaaaaab516d30, flags=...)
				at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qeventdispatcher_glib.cpp:402
		#25 0x0000fffff614c084 [PAC] in QEventLoop::exec (this=this@entry=0xffffffffcad0, flags=flags@entry=...) at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/global/qflags.h:78
		#26 0x0000fffff6146bc4 [PAC] in QCoreApplication::exec () at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/corelib/kernel/qcoreapplication.cpp:1457
		#27 0x0000fffff6ab3ad4 [PAC] in QGuiApplication::exec () at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/gui/kernel/qguiapplication.cpp:2005
		#28 0x0000fffff75e6044 in QApplication::exec () at /usr/src/debug/qt6-qtbase-6.11.1-1.fc44.aarch64/src/widgets/kernel/qapplication.cpp:2546
		#29 0x0000aaaaaaad66d8 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/indigo-imager-2.13.0-1.fc44.aarch64/ain_imager_src/main.cpp:280

This happens because `snprintf()` is called with wrong length and `snprintf()`  with `_FORTIFY_SOURCE=2` is able to validate the sizes of statically allocated buffers.

## Audio-related crash on shutdown

Log:

		07:47:37.370794 ain_imager: INDIGO Bus: can't stop, '@ rsdesktop' is attached
		QEventLoop: Cannot be used without QCoreApplication
		qt.core.qobject.connect: QObject::connect(QObject, Unknown): invalid nullptr parameter

Backtrace:

		#0  pw_stream_disconnect (stream=0x0) at ../src/pipewire/stream.c:2274
		#1  0x0000fffff73a7064 [PAC] in pw_stream_disconnect (a0=<optimized out>) at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_symbolloader.cpp:81
		#2  operator() (__closure=<optimized out>) at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_audiostream.cpp:152
		#3  QtPipeWire::QAudioContextManager::withEventLoopLock<QtPipeWire::QPipewireAudioStream::disconnectStream()::<lambda()> > (c=<optimized out>)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_audiocontextmanager_p.h:54
		#4  QtPipeWire::QPipewireAudioStream::disconnectStream (this=0xaaaaac5af400) at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_audiostream.cpp:151
		#5  0x0000fffff7395680 [PAC] in QtPipeWire::QPipewireAudioSinkStream::disconnectStream (this=0xaaaaac5af400)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_audiosink.cpp:346
		#6  QtPipeWire::QPipewireAudioSinkStream::stop (this=0xaaaaac5af400, shutdownPolicy=shutdownPolicy@entry=QtMultimediaPrivate::QPlatformAudioIOStream::ShutdownPolicy::DiscardRingbuffer)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/pipewire/qpipewire_audiosink.cpp:157
		#7  0x0000fffff7399564 [PAC] in QtMultimediaPrivate::QPlatformAudioSinkImplementation<QtPipeWire::QPipewireAudioSinkStream, QtPipeWire::QPipewireAudioSink>::reset (this=0xaaaaacff9c00)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/audio/qaudio_platform_implementation_support_p.h:234
		#8  0x0000fffff73166bc [PAC] in QtMultimediaPrivate::QRtAudioEngine::~QRtAudioEngine (this=0xaaaaac474350, this=<optimized out>)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/audio/qrtaudioengine.cpp:82
		#9  0x0000fffff7317000 [PAC] in QtMultimediaPrivate::QRtAudioEngine::~QRtAudioEngine (this=0xaaaaac474350, this=<optimized out>)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/audio/qrtaudioengine.cpp:89
		#10 0x0000fffff72f89e8 [PAC] in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use (this=0xaaaaad003fa0) at /usr/include/c++/16/bits/shared_ptr_base.h:174
		#11 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold (this=0xaaaaad003fa0) at /usr/include/c++/16/bits/shared_ptr_base.h:198
		#12 0x0000fffff731a5c0 [PAC] in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0xaaaaad003fa0) at /usr/include/c++/16/bits/shared_ptr_base.h:430
		#13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0xaaaaad16d538, this=<optimized out>) at /usr/include/c++/16/bits/shared_ptr_base.h:1136
		#14 std::__shared_ptr<QtMultimediaPrivate::QRtAudioEngine, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0xaaaaad16d530, this=<optimized out>)
				at /usr/include/c++/16/bits/shared_ptr_base.h:1610
		#15 std::shared_ptr<QtMultimediaPrivate::QRtAudioEngine>::~shared_ptr (this=0xaaaaad16d530, this=<optimized out>) at /usr/include/c++/16/bits/shared_ptr.h:175
		#16 QtMultimediaPrivate::QSoundEffectPrivateWithPlayer::~QSoundEffectPrivateWithPlayer (this=0xaaaaad16d490, this=<optimized out>)
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/audio/qsoundeffectwithplayer.cpp:257
		#17 0x0000fffff731a618 [PAC] in non-virtual thunk to QtMultimediaPrivate::QSoundEffectPrivateWithPlayer::~QSoundEffectPrivateWithPlayer() ()
				at /usr/src/debug/qt6-qtmultimedia-6.11.1-1.fc44.aarch64/src/multimedia/audio/qsoundeffectwithplayer_p.h:82
		#18 0x0000fffff5a5e4ec [PAC] in __run_exit_handlers (status=0, listp=0xfffff5be0658 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true)
				at exit.c:118
		#19 0x0000fffff5a5e5e0 [PAC] in __GI_exit (status=<optimized out>) at exit.c:148
		#20 0x0000fffff5a46f20 [PAC] in __libc_start_call_main (main=main@entry=0xaaaaaaad5f40 <main(int, char**)>, argc=argc@entry=1, argv=argv@entry=0xffffffffeb78)
				at ../sysdeps/nptl/libc_start_call_main.h:83
		#21 0x0000fffff5a4705c [PAC] in __libc_start_main_impl
				(main=0xaaaaaaad5f40 <main(int, char**)>, argc=1, argv=0xffffffffeb78, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=<optimized out>)
				at ../csu/libc-start.c:360
		#22 0x0000aaaaaaad6ff0 [PAC] in _start ()

This happens because the destructor of `static QSoundEffect sound_effect` is
called too late during the shutdown.
